### PR TITLE
Update file because error

### DIFF
--- a/jenkins_setup_Ubuntu_CentOS.txt
+++ b/jenkins_setup_Ubuntu_CentOS.txt
@@ -9,6 +9,7 @@ wget -q -O - https://pkg.jenkins.io/debian-stable/jenkins.io.key | sudo apt-key 
 sudo sh -c 'echo deb https://pkg.jenkins.io/debian-stable binary/ > /etc/apt/sources.list.d/jenkins.list'
 
 sudo apt-get update
+sudo apt-get install -y ca-certificates
 sudo apt-get install -y jenkins
 sudo systemctl start jenkins
 sudo systemctl status jenkins


### PR DESCRIPTION
there was an error when i try to install it on new ubuntu machine, Error is:- Err:5 https://pkg.jenkins.io/debian-stable binary/ Release                             
  Certificate verification failed: The certificate is NOT trusted. The certificate chain uses expired certificate.  Could not handshake: Error in the certificate verification. [IP: 151.101.122.133 443]
### this error appears when using "apt-get update" after adding Jenkins repo
#### this is the best solution for this problem: sudo apt-get install -y ca-certificates